### PR TITLE
Expose additional settlement totals on client dashboard

### DIFF
--- a/laucxserver-main/frontend/src/pages/client/dashboard.tsx
+++ b/laucxserver-main/frontend/src/pages/client/dashboard.tsx
@@ -45,10 +45,10 @@ export default function ClientDashboardPage() {
 
   // Summary
   const [balance, setBalance]                 = useState(0)
-  const [totalPend, setTotalPend]             = useState(0)
-  const [totalTrans, setTotalTrans]           = useState(0) // from backend (count)
-    const [totalSettlement, setTotalSettlement] = useState(0)
-  const [totalPaid, setTotalPaid]             = useState(0)
+  const [totalBeforeFee, setTotalBeforeFee]   = useState(0)
+  const [finalTotal, setFinalTotal]           = useState(0)
+  const [pendingSettlement, setPendingSettlement] = useState(0)
+  const [totalSettlement, setTotalSettlement] = useState(0)
   const [exporting, setExporting]             = useState(false)
   // Transactions
   const [txs, setTxs]                         = useState<Tx[]>([])
@@ -137,19 +137,20 @@ export default function ClientDashboardPage() {
     try {
       const { data } = await api.get<{
         balance: number
-        totalPending: number
-        totalCount: number
+        totalBeforeFee: number
+        finalTotal: number
+        pendingSettlement: number
         totalSettlement?: number
-        totalPaid?: number
+        totalPending?: number
         children: ClientOption[]
       }>('/client/dashboard', { params: buildParams() })
 
       setBalance(data.balance)
-      setTotalPend(data.totalPending)
+      setTotalBeforeFee(data.totalBeforeFee || 0)
+      setFinalTotal(data.finalTotal || 0)
+      setPendingSettlement(data.pendingSettlement ?? data.totalPending ?? 0)
       setTotalSettlement(data.totalSettlement || 0)
-      setTotalPaid(data.totalPaid || 0)
       setChildren(data.children)
-      setTotalTrans(data.totalCount)
     } catch {
       router.push('/client/login')
     } finally {
@@ -274,28 +275,24 @@ try {
         <section className={styles.statsGrid}>
           <div className={styles.card}>
             <ListChecks className={styles.cardIcon} />
-            <h2>Transactions</h2>
-                        <p>{totalTrans.toLocaleString()}</p>
+            <h2>Total Sebelum Fee</h2>
+            <p>{totalBeforeFee.toLocaleString('id-ID',{ style:'currency', currency:'IDR' })}</p>
+          </div>
+          <div className={styles.card}>
+            <ClipboardCopy className={styles.cardIcon} />
+            <h2>Total Akhir</h2>
+            <p>{finalTotal.toLocaleString('id-ID',{ style:'currency', currency:'IDR' })}</p>
           </div>
           <div className={`${styles.card} ${styles.pendingBalance}`}>
             <Clock className={styles.cardIcon} />
             <h2>Pending Settlement</h2>
-                        <p>{totalPend.toLocaleString('id-ID',{ style:'currency', currency:'IDR' })}</p>
+            <p>{pendingSettlement.toLocaleString('id-ID',{ style:'currency', currency:'IDR' })}</p>
           </div>
-                    <div className={`${styles.card} ${styles.paidBalance}`}>
+          <div className={`${styles.card} ${styles.paidBalance}`}>
             <Wallet className={styles.cardIcon} />
             <h2>Total Settlement</h2>
             <p>{totalSettlement.toLocaleString('id-ID',{ style:'currency', currency:'IDR' })}</p>
           </div>
-{/* <div className={`${styles.card} ${styles.paidBalance}`}>
-  <Wallet className={styles.cardIcon} />
-  <div style={{ display: 'flex', flexDirection: 'column' }}>
-    <h2 style={{ margin: 0 }}>Total Paid</h2>
-    <small style={{ fontSize: 12, color: '#666' }}>after fee</small>
-  </div>
-  <p>{totalPaid.toLocaleString('id-ID',{ style:'currency', currency:'IDR' })}</p>
-</div> */}
-
         </section>
       </aside>
 


### PR DESCRIPTION
## Summary
- aggregate pending, settlement, and pre-fee totals for client dashboard
- surface before-fee and final totals in client dashboard response
- show new settlement summary cards on client dashboard page

## Testing
- `npm test` (no tests found)
- `npm run build` *(fails: Module '@prisma/client' has no exported member 'DisbursementStatus')*


------
https://chatgpt.com/codex/tasks/task_e_689624a0572c832882205aac1629d989