### PR TITLE
feat: add total fee to dashboard

### DIFF
--- a/laucxserver-main/frontend/src/components/dashboard/TransactionsTable.tsx
+++ b/laucxserver-main/frontend/src/components/dashboard/TransactionsTable.tsx
@@ -119,6 +119,7 @@ export default function TransactionsTable({
                   <th>Amount</th>
                   <th>Fee Launcx</th>
                   <th>Fee PG</th>
+                  <th>Total Fee</th>
                   <th>Net Amount</th>
                   <th>Status</th>
                   <th>Settlement Status</th>
@@ -157,6 +158,7 @@ export default function TransactionsTable({
                     <td>{t.amount.toLocaleString('id-ID', { style:'currency', currency:'IDR' })}</td>
                     <td>{t.feeLauncx.toLocaleString('id-ID', { style:'currency', currency:'IDR' })}</td>
                     <td>{t.feePg.toLocaleString('id-ID', { style:'currency', currency:'IDR' })}</td>
+                    <td>{t.totalFee.toLocaleString('id-ID', { style:'currency', currency:'IDR' })}</td>
                     <td className={styles.netSettle}>{t.netSettle.toLocaleString('id-ID', { style:'currency', currency:'IDR' })}</td>
                     <td>{t.status || '-'}</td>
                     <td>

--- a/laucxserver-main/frontend/src/pages/dashboard.tsx
+++ b/laucxserver-main/frontend/src/pages/dashboard.tsx
@@ -35,6 +35,7 @@ type RawTx = {
   amount?: number
   feeLauncx?: number
   feePg?: number
+  totalFee?: number
   pendingAmount?: number
   settlementAmount?: number
   status?: string
@@ -480,6 +481,7 @@ const mapped: Tx[] = data.transactions.map(o => {
     amount:             o.amount ?? 0,
     feeLauncx:          o.feeLauncx ?? 0,
     feePg:              o.feePg ?? 0,
+    totalFee:           o.totalFee ?? 0,
     netSettle:          o.netSettle,
     status:             statusTyped,                                // <<< revisi
     settlementStatus:   o.settlementStatus.replace(/_/g, ' '),

--- a/laucxserver-main/frontend/src/types/dashboard.ts
+++ b/laucxserver-main/frontend/src/types/dashboard.ts
@@ -6,6 +6,7 @@ export type Tx = {
   amount: number
   feeLauncx: number
   feePg: number
+  totalFee: number
   netSettle: number
   status: '' | 'SUCCESS' | 'PENDING' | 'EXPIRED' | 'DONE' | 'PAID'
   settlementStatus: string

--- a/laucxserver-main/src/controller/admin/merchant.controller.ts
+++ b/laucxserver-main/src/controller/admin/merchant.controller.ts
@@ -466,6 +466,7 @@ export async function getDashboardTransactions(req: Request, res: Response) {
       const pend = o.pendingAmount    ?? 0
       const sett = o.settlementAmount ?? 0
       const netSettle = o.status === 'PAID' ? pend : sett
+      const totalFee = (o.feeLauncx ?? 0) + (o.fee3rdParty ?? 0)
 
       return {
         id:                   o.id,
@@ -476,6 +477,7 @@ export async function getDashboardTransactions(req: Request, res: Response) {
         amount:               o.amount,
         feeLauncx:            o.feeLauncx   ?? 0,
         feePg:                o.fee3rdParty ?? 0,
+        totalFee,
         netSettle,
         status:               o.status === 'SETTLED' ? 'SUCCESS' : o.status,
         settlementStatus:     o.settlementStatus ?? '',
@@ -951,7 +953,7 @@ export async function exportDashboardAll(req: Request, res: Response) {
     const txSheet = wb.addWorksheet('Transactions')
     txSheet.addRow([
       'Date','TRX ID','RRN','Player ID','Channel',
-      'Amount','Fee Launcx','Fee PG','Net Amount','Status'
+      'Amount','Fee Launcx','Fee PG','Total Fee','Net Amount','Status'
     ]).commit()
 
     let skipOrders = 0
@@ -978,6 +980,7 @@ export async function exportDashboardAll(req: Request, res: Response) {
 
       for (const o of ordersChunk) {
         const net = o.status === 'PAID' ? o.pendingAmount : o.settlementAmount
+        const totalFee = (o.feeLauncx ?? 0) + (o.fee3rdParty ?? 0)
         txSheet.addRow([
           formatDateJakarta(o.createdAt),
           o.id,
@@ -987,6 +990,7 @@ export async function exportDashboardAll(req: Request, res: Response) {
           o.amount,
           o.feeLauncx,
           o.fee3rdParty,
+          totalFee,
           net,
           o.status
         ]).commit()


### PR DESCRIPTION
## Summary
- include combined fee in dashboard transactions
- export total fee column in dashboard report
- show total fee column on dashboard UI

## Testing
- `npm test` (fails: Could not find '/workspace/launcxmain/laucxserver-main/test/**/*.test.ts')
- `cd frontend && npm run build`
- `node -e "process.env.JWT_SECRET='test'; ... exportDashboardAll ..."` then verified `Total Fee` column in `/tmp/export.xlsx`


------
https://chatgpt.com/codex/tasks/task_e_689642c0d57c83289ec390b3c4fcbdfa